### PR TITLE
fix: getting articles based on pagination link

### DIFF
--- a/utils/constant.py
+++ b/utils/constant.py
@@ -4,3 +4,9 @@ SUMMARIZE_INSTRUCTION = "Ringkas artikel berikut menjadi 1 paragraf. Berikan poi
 # Gemini
 API_KEY_NOT_FOUND = "You need to insert Gemini API Key first!"
 RESPONSE_NOT_FOUND = "No Response from AI"
+
+# Response
+No_NEWS_YE = "Belum ada berita untuk sekarang"
+
+# Timeout
+PAGE_LOAD_TIMEOUT = 5


### PR DESCRIPTION
* Implement retry decorator for `do_get_article` func to the child `DetikNews class`
* Getting articles from the pagination links, not from pagination nums
* Set constatnt `timeout` duraiton and add it to exception
* Close driver when it's finished